### PR TITLE
 [sms-client] Unmarshal http response to struct Response directly.

### DIFF
--- a/sms-client.go
+++ b/sms-client.go
@@ -24,27 +24,30 @@ func New(gatewayUrl string) *SmsClient {
 	return smsClient
 }
 
-func (smsClient *SmsClient) Execute(accessKeyId, accessKeySecret, phoneNumbers, signName, templateCode, templateParam string) (result map[string]interface{}, err error) {
-	var endpoint string
-	if err = smsClient.Request.SetParamsValue(accessKeyId, phoneNumbers, signName, templateCode, templateParam); err != nil {
-		return
+func (smsClient *SmsClient) Execute(accessKeyId, accessKeySecret, phoneNumbers, signName, templateCode, templateParam string) (*Response, error) {
+	err := smsClient.Request.SetParamsValue(accessKeyId, phoneNumbers, signName, templateCode, templateParam)
+	if err != nil {
+		return nil, err
 	}
-	if endpoint, err = smsClient.Request.BuildSmsRequestEndpoint(accessKeySecret, smsClient.GatewayUrl); err != nil {
-		return
+	endpoint, err := smsClient.Request.BuildSmsRequestEndpoint(accessKeySecret, smsClient.GatewayUrl)
+	if err != nil {
+		return nil, err
 	}
 
 	request, _ := http.NewRequest("GET", endpoint, nil)
 	response, err := smsClient.Client.Do(request)
 	if err != nil {
-		return
+		return nil, err
 	}
 	body, err := ioutil.ReadAll(response.Body)
 	if err != nil {
-		return
+		return nil, err
 	}
 	defer response.Body.Close()
 
-	err = json.Unmarshal(body, &result)
+	result := new(Response)
+	err = json.Unmarshal(body, result)
 
-	return
+	result.RawResponse = body
+	return result, err
 }

--- a/sms-response.go
+++ b/sms-response.go
@@ -1,0 +1,20 @@
+package aliyunsmsclient
+
+// The response code which stands for a sms is sent successfully.
+const ResponseCodeOk = "OK"
+
+// @see https://help.aliyun.com/document_detail/55284.html#出参列表
+// The Response of sending sms API.
+type Response struct {
+	// The raw response from server.
+	RawResponse []byte `json:"-"`
+	/* Response body */
+	RequestId string `json:"RequestId"`
+	Code      string `json:"Code"`
+	Message   string `json:"Message"`
+	BizId     string `json:"BizId"`
+}
+
+func (m *Response) IsSuccessful() bool {
+	return m.Code == ResponseCodeOk
+}


### PR DESCRIPTION
Hi Kenmy,

I suppose an unmarshalled Response struct of sending SMS will make things easier for callers, so I added a type Response struct as shown below and changed the `./sms-client.go#Execute()` method.

Thank you for reviewing the codes!

```go
// The response code which stands for a sms is sent successfully.
const ResponseCodeOk = "OK"

// @see https://help.aliyun.com/document_detail/55284.html#出参列表
// The Response of sending sms API.
type Response struct {
	// The raw response from server.
	RawResponse []byte `json:"-"`
	/* Response body */
	RequestId string `json:"RequestId"`
	Code      string `json:"Code"`
	Message   string `json:"Message"`
	BizId     string `json:"BizId"`
}

func (m *Response) IsSuccessful() bool {
	return m.Code == ResponseCodeOk
}
```

你好Kenmy, 我觉得直接讲请求结果反序列为一个结构体会对调用者比较友好，所以如上我添加了一个Response结构体并修改了 `./sms-client.go#Execute()` 。

谢谢进行审查。

Yu Zhanbei