### PR TITLE
修复在go 1.22下的报错encoding/base32.NewEncoding(…)

### DIFF
--- a/sms-lib/sms-lib.go
+++ b/sms-lib/sms-lib.go
@@ -42,7 +42,7 @@ type ALiYunCommunicationRequest struct {
 	OutId           string
 }
 
-var encoding = base32.NewEncoding("ybndrfg8ejkmcpqxot1uwisza345h897")
+var encoding = base32.NewEncoding("ybndrfg8ejkmcpqxot1uwisza345h697")
 
 func NewId() string {
 	var b bytes.Buffer


### PR DESCRIPTION
因为 go 1.22 版本中 base64.NewEncoding 函数对入参增加了新的验证：不可重复字符，参考：encoding: require unique alphabet for base32 and base64